### PR TITLE
feat: Helm Chart

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
   - id: check-yaml
     args: ["-m", "--unsafe"]
     stages: [commit]
+    exclude: ^charts/
   - id: mixed-line-ending
     args: ["-f", "lf"]
     exclude: \.bat$

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
+helm 3.10.0
 golang 1.20.2
 golangci-lint 1.51.2
 pre-commit 3.1.1

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ test:
 
 .PHONY: lint
 lint:
+	helm lint --strict ./charts/troubleshoot-live
 	golangci-lint run --fix
 
 ifndef GORELEASER_CURRENT_TAG

--- a/charts/troubleshoot-live/.helmignore
+++ b/charts/troubleshoot-live/.helmignore
@@ -23,4 +23,3 @@
 .vscode/
 
 example.yaml
-

--- a/charts/troubleshoot-live/.helmignore
+++ b/charts/troubleshoot-live/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+example.yaml

--- a/charts/troubleshoot-live/.helmignore
+++ b/charts/troubleshoot-live/.helmignore
@@ -23,3 +23,4 @@
 .vscode/
 
 example.yaml
+

--- a/charts/troubleshoot-live/Chart.yaml
+++ b/charts/troubleshoot-live/Chart.yaml
@@ -22,3 +22,5 @@ version: 0.1.0
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v0.1.0-dev"
+
+icon: https://raw.githubusercontent.com/kubernetes/community/master/icons/svg/resources/unlabeled/pod.svg

--- a/charts/troubleshoot-live/Chart.yaml
+++ b/charts/troubleshoot-live/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: troubleshoot-live
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.1.0-dev"

--- a/charts/troubleshoot-live/example.yaml
+++ b/charts/troubleshoot-live/example.yaml
@@ -1,0 +1,15 @@
+# Init containers can use volume `shared-data` to prepare bundle data for serve command.
+initContainers:
+  - name: download-bundle
+    image: alpine/curl
+    command: ['sh', '-c', "curl -fsL https://mh-test-kind.s3.us-west-2.amazonaws.com/sleepy-cohen-support-bundle-2023-03-31T07_18_45.tar.gz
+ -o /data/bundle.tar.gz"]
+    volumeMounts:
+      - name: shared-data
+        mountPath: /data
+
+# Provide run argument
+args: ["serve", "/data/bundle.tar.gz", "-v", "1", "--output-kubeconfig", "/data/support-bundle-kubeconfig", "--proxy-address", ":8080"]
+
+image:
+  tag: "v0.0.10"

--- a/charts/troubleshoot-live/templates/_helpers.tpl
+++ b/charts/troubleshoot-live/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "troubleshoot-live.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "troubleshoot-live.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "troubleshoot-live.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "troubleshoot-live.labels" -}}
+helm.sh/chart: {{ include "troubleshoot-live.chart" . }}
+{{ include "troubleshoot-live.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "troubleshoot-live.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "troubleshoot-live.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "troubleshoot-live.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "troubleshoot-live.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/troubleshoot-live/templates/deployment.yaml
+++ b/charts/troubleshoot-live/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "troubleshoot-live.fullname" . }}
+  labels:
+    {{- include "troubleshoot-live.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "troubleshoot-live.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "troubleshoot-live.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "troubleshoot-live.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+      - name: shared-data
+        emptyDir: {}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          # https://kubernetes.io/docs/reference/using-api/health-checks/#api-endpoints-for-health
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: shared-data
+              mountPath: /data
+      restartPolicy: Always
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/troubleshoot-live/templates/service.yaml
+++ b/charts/troubleshoot-live/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "troubleshoot-live.fullname" . }}
+  labels:
+    {{- include "troubleshoot-live.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "troubleshoot-live.selectorLabels" . | nindent 4 }}

--- a/charts/troubleshoot-live/templates/serviceaccount.yaml
+++ b/charts/troubleshoot-live/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "troubleshoot-live.serviceAccountName" . }}
+  labels:
+    {{- include "troubleshoot-live.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/troubleshoot-live/templates/tests/test-connection.yaml
+++ b/charts/troubleshoot-live/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "troubleshoot-live.fullname" . }}-test-connection"
+  labels:
+    {{- include "troubleshoot-live.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "troubleshoot-live.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/troubleshoot-live/values.yaml
+++ b/charts/troubleshoot-live/values.yaml
@@ -1,0 +1,81 @@
+# Default values for troubleshoot-live.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/mhrabovcin/troubleshoot-live
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 8080
+
+# Init containers can use volume `shared-data` to prepare bundle data for serve command.
+# initContainers:
+#   - name: download-bundle
+#     image: busybox:1.28
+#     command: ['sh', '-c', "curl -fsL https://exmaple.com/bundle.tar.gz -o /data/bundle.tar.gz"]
+#     volumeMounts:
+#       - name: shared-data
+#         mountPath: /data
+initContainers: []
+
+# Provide run argument
+# args:
+# - "serve"
+# - "/data/bundle.tar.gz"
+# - "-v"
+# - "1"
+# - "--output-kubeconfig"
+# - "/data/support-bundle-kubeconfig"
+# - "--proxy-address"
+# - ":8080"
+args: []
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This mainly piggy-backs on @mhrabovcin's [helm-chart](https://github.com/mhrabovcin/troubleshoot-live/tree/helm-chart) branch, the chart templates were defined there.

- Excludes helm-templates from `check-yaml`
- Adds a strict linter for helm-templates
- Adds a placeholder icon for strict helm linter to pass.