### PR TITLE
feat: Github Actions to publish Helm Charts.

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -1,0 +1,28 @@
+name: Release Charts
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: "${{ secrets.GHP_TOKEN }}"

--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -16,8 +16,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Install Helm
         uses: azure/setup-helm@v3


### PR DESCRIPTION
This uses [Helm Chart Releaser](https://github.com/helm/chart-releaser-action) Action to publish the helm chart.
This requires the following:
- GitHub pages set to `gh-pages` branch.
- Token called `GHP_TOKEN` with at least `Contents` permissions. (feel free to use another one here as needed)

This has been tested and working in my fork. 
I see the [v0.0.10](https://github.com/mhrabovcin/troubleshoot-live/releases/tag/troubleshoot-live-v0.0.10) chart released but didn't find any GHA workflows in any branch. So if this is redundant, please feel free to close this PR.