### PR TITLE
fix: correctly rewrite deletionGracePeriodSeconds

### DIFF
--- a/pkg/rewriter/generated.go
+++ b/pkg/rewriter/generated.go
@@ -7,6 +7,7 @@ func GeneratedValues() ResourceRewriter {
 		RemoveField("metadata", "generateName"),
 		RemoveField("metadata", "creationTimestamp"),
 		RemoveField("metadata", "deletionTimestamp"),
+		RemoveField("metadata", "deletionGracePeriodSeconds"),
 		RemoveField("metadata", "uid"),
 		RemoveField("metadata", "resourceVersion"),
 	)

--- a/pkg/rewriter/generated_test.go
+++ b/pkg/rewriter/generated_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 )
 
 func TestGeneratedValues(t *testing.T) {
@@ -17,26 +18,29 @@ func TestGeneratedValues(t *testing.T) {
 	timestamp := metav1.NewTime(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName:      "generated-",
-			CreationTimestamp: timestamp,
-			DeletionTimestamp: &timestamp,
-			UID:               types.UID("1000"),
-			ResourceVersion:   "2000",
+			GenerateName:               "generated-",
+			CreationTimestamp:          timestamp,
+			DeletionTimestamp:          &timestamp,
+			DeletionGracePeriodSeconds: ptr.To(int64(30)),
+			UID:                        types.UID("1000"),
+			ResourceVersion:            "2000",
 		},
 	}
 	pod = testRewriterBeforeImport(t, r, pod)
 	assert.Empty(t, pod.GetGenerateName())
 	assert.Empty(t, pod.GetCreationTimestamp())
 	assert.Empty(t, pod.GetDeletionTimestamp())
+	assert.Empty(t, pod.GetDeletionGracePeriodSeconds())
 	assert.Empty(t, pod.GetUID())
 	assert.Empty(t, pod.GetResourceVersion())
 
-	expectedFields := map[string]string{
-		"generateName":      "generated-",
-		"creationTimestamp": "2023-01-01T00:00:00Z",
-		"deletionTimestamp": "2023-01-01T00:00:00Z",
-		"uid":               "1000",
-		"resourceVersion":   "2000",
+	expectedFields := map[string]any{
+		"generateName":               "generated-",
+		"creationTimestamp":          "2023-01-01T00:00:00Z",
+		"deletionTimestamp":          "2023-01-01T00:00:00Z",
+		"deletionGracePeriodSeconds": 30,
+		"uid":                        "1000",
+		"resourceVersion":            "2000",
 	}
 	for k, v := range expectedFields {
 		fieldName := fmt.Sprintf("metadata.%s", k)
@@ -44,13 +48,14 @@ func TestGeneratedValues(t *testing.T) {
 		assert.Contains(t, pod.GetAnnotations(), annotation, "annotation %q missing", fieldName)
 		var unserialized any
 		assert.NoError(t, json.Unmarshal([]byte(pod.GetAnnotations()[annotation]), &unserialized))
-		assert.Equal(t, v, unserialized, "wrong value stored in %q", fieldName)
+		assert.EqualValues(t, v, unserialized, "wrong value stored in %q metadata %q", fieldName, pod.GetAnnotations()[annotation])
 	}
 
 	pod = testRewriterBeforeServing(t, r, pod)
 	assert.Equal(t, "generated-", pod.GetGenerateName())
 	assert.Equal(t, timestamp.Format(time.RFC3339), pod.GetCreationTimestamp().In(time.UTC).Format(time.RFC3339))
 	assert.Equal(t, timestamp.Format(time.RFC3339), pod.GetDeletionTimestamp().In(time.UTC).Format(time.RFC3339))
+	assert.Equal(t, int64(30), ptr.Deref(pod.GetDeletionGracePeriodSeconds(), 0))
 	assert.Equal(t, types.UID("1000"), pod.GetUID())
 	assert.Equal(t, "2000", pod.GetResourceVersion())
 }


### PR DESCRIPTION
Fixing panic in `kubectl` that correctly expects that field `deletionGracePeriodSeconds` is populated when a Pod resource is being deleted and the `deleteTimestamp` is present.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x101ff4564]

goroutine 1 [running]:
k8s.io/kubectl/pkg/describe.describePod.func1({0x102bbd678?, 0x140005480b0})
        vendor/k8s.io/kubectl/pkg/describe/describe.go:813 +0x404
k8s.io/kubectl/pkg/describe.tabbedString(0x140004657e0)
        vendor/k8s.io/kubectl/pkg/describe/describe.go:5225 +0x80
k8s.io/kubectl/pkg/describe.describePod(0x12b825128?, 0x14000b3ee40?)
        vendor/k8s.io/kubectl/pkg/describe/describe.go:785 +0x3c
k8s.io/kubectl/pkg/describe.(*PodDescriber).Describe(0x14000b3f010, {0x16f232ee9, 0xf}, {0x16f232ebc, 0x29}, {0xe8?, 0x14000663a98?})
        vendor/k8s.io/kubectl/pkg/describe/describe.go:781 +0x48c
k8s.io/kubectl/pkg/cmd/describe.(*DescribeOptions).Run(0x140005f45a0)
        vendor/k8s.io/kubectl/pkg/cmd/describe/describe.go:209 +0x440
k8s.io/kubectl/pkg/cmd/describe.NewCmdDescribe.func1(0x140004d8e00?, {0x140005fc100?, 0x2?, 0x4?})
        vendor/k8s.io/kubectl/pkg/cmd/describe/describe.go:158 +0x80
github.com/spf13/cobra.(*Command).execute(0x1400053d200, {0x140005fc0c0, 0x4, 0x4})
        vendor/github.com/spf13/cobra/command.go:944 +0x654
github.com/spf13/cobra.(*Command).ExecuteC(0x140001e2300)
        vendor/github.com/spf13/cobra/command.go:1068 +0x320
github.com/spf13/cobra.(*Command).Execute(...)
        vendor/github.com/spf13/cobra/command.go:992
k8s.io/component-base/cli.run(0x140001e2300)
        vendor/k8s.io/component-base/cli/run.go:146 +0x264
k8s.io/component-base/cli.RunNoErrOutput(...)
        vendor/k8s.io/component-base/cli/run.go:84
main.main()
        cmd/kubectl/kubectl.go:30 +0x20
```