### PR TITLE
feat: support providing api server feature gates

### DIFF
--- a/pkg/envtest/environment.go
+++ b/pkg/envtest/environment.go
@@ -6,9 +6,13 @@ import (
 	"fmt"
 	"net/url"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
 
 	"k8s.io/client-go/rest"
 	controllerruntimeenvtest "sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/versions"
 )
 
 // DatastoreConnection describes datastore endpoint details for API server wiring.
@@ -21,6 +25,12 @@ type DatastoreConnection struct {
 type APIServerStorageConfig struct {
 	Endpoint *url.URL
 	Prefix   string
+}
+
+// APIServerStartConfig defines configuration passed to API server startup.
+type APIServerStartConfig struct {
+	Storage      APIServerStorageConfig
+	FeatureGates map[string]bool
 }
 
 // Datastore is a handle for datastore lifecycle and connection details.
@@ -72,7 +82,8 @@ type Environment struct {
 	ControlPlane          controllerruntimeenvtest.ControlPlane
 	Config                *rest.Config
 
-	storageConfig APIServerStorageConfig
+	k8sVersion  versions.Selector
+	startConfig APIServerStartConfig
 
 	apiServerStarted bool
 
@@ -81,12 +92,16 @@ type Environment struct {
 	addAdminUserFn   func(*controllerruntimeenvtest.ControlPlane) (*rest.Config, error)
 }
 
-func newEnvironment(binaryAssetsDirectory string) *Environment {
+func newEnvironment(binaryAssetsDirectory string, k8sVersion versions.Selector) *Environment {
 	return &Environment{
 		BinaryAssetsDirectory: binaryAssetsDirectory,
-		startAPIServerFn:      startAPIServer,
-		stopAPIServerFn:       stopAPIServer,
-		addAdminUserFn:        addAdminUser,
+		k8sVersion:            k8sVersion,
+		startConfig: APIServerStartConfig{
+			FeatureGates: map[string]bool{},
+		},
+		startAPIServerFn: startAPIServer,
+		stopAPIServerFn:  stopAPIServer,
+		addAdminUserFn:   addAdminUser,
 	}
 }
 
@@ -107,14 +122,17 @@ func (e *Environment) Start(opts ...StartOption) (*rest.Config, error) {
 		apiServer.Path = filepath.Join(e.BinaryAssetsDirectory, "kube-apiserver")
 	}
 
-	storageCfg := e.storageConfig
+	startCfg := e.startConfig
+	startCfg.FeatureGates = copyFeatureGates(startCfg.FeatureGates)
 	for _, opt := range opts {
-		opt(&storageCfg)
+		opt(&startCfg)
 	}
+	defaultAPIServerFeatureGates(startCfg.FeatureGates, e.k8sVersion)
 
-	if err := configureAPIServerStorage(apiServer, storageCfg); err != nil {
+	if err := configureAPIServerStorage(apiServer, startCfg.Storage); err != nil {
 		return nil, err
 	}
+	configureAPIServerFeatureGates(apiServer, startCfg.FeatureGates)
 
 	if err := e.startAPIServerFn(apiServer); err != nil {
 		return nil, fmt.Errorf("failed to start api server: %w", err)
@@ -154,6 +172,60 @@ func configureAPIServerStorage(apiServer *controllerruntimeenvtest.APIServer, cf
 		apiServer.Configure().Set("etcd-prefix", cfg.Prefix)
 	}
 	return nil
+}
+
+func copyFeatureGates(featureGates map[string]bool) map[string]bool {
+	copied := make(map[string]bool, len(featureGates))
+	for name, enabled := range featureGates {
+		copied[name] = enabled
+	}
+	return copied
+}
+
+func defaultAPIServerFeatureGates(featureGates map[string]bool, k8sVersion versions.Selector) {
+	if featureGates == nil {
+		return
+	}
+	if _, ok := featureGates["WatchList"]; ok {
+		return
+	}
+	if supportsWatchList(k8sVersion) {
+		featureGates["WatchList"] = true
+	}
+}
+
+func configureAPIServerFeatureGates(apiServer *controllerruntimeenvtest.APIServer, featureGates map[string]bool) {
+	if len(featureGates) == 0 {
+		return
+	}
+
+	names := make([]string, 0, len(featureGates))
+	for name := range featureGates {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	values := make([]string, 0, len(names))
+	for _, name := range names {
+		values = append(values, name+"="+strconv.FormatBool(featureGates[name]))
+	}
+	apiServer.Configure().Set("feature-gates", strings.Join(values, ","))
+}
+
+func supportsWatchList(k8sVersion versions.Selector) bool {
+	if k8sVersion == nil {
+		return false
+	}
+
+	switch v := k8sVersion.(type) {
+	case versions.Concrete:
+		return v.Major > 1 || (v.Major == 1 && v.Minor >= 27)
+	case versions.PatchSelector:
+		return v.Major > 1 || (v.Major == 1 && v.Minor >= 27)
+	default:
+		concrete := k8sVersion.AsConcrete()
+		return concrete != nil && (concrete.Major > 1 || (concrete.Major == 1 && concrete.Minor >= 27))
+	}
 }
 
 func startAPIServer(apiServer *controllerruntimeenvtest.APIServer) error {

--- a/pkg/envtest/environment_test.go
+++ b/pkg/envtest/environment_test.go
@@ -8,7 +8,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/rest"
 	controllerruntimeenvtest "sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/versions"
 )
+
+func testK8sVersion(minor int) versions.Selector {
+	return versions.PatchSelector{
+		Major: 1,
+		Minor: minor,
+		Patch: versions.AnyPoint,
+	}
+}
 
 func TestNewLocalEtcdDatastoreUsesBinaryAssetsDirectory(t *testing.T) {
 	ds := NewLocalEtcdDatastore("/tmp/envtest-assets")
@@ -19,7 +28,7 @@ func TestNewLocalEtcdDatastoreUsesBinaryAssetsDirectory(t *testing.T) {
 }
 
 func TestEnvironmentStartRequiresStorageEndpoint(t *testing.T) {
-	env := newEnvironment("/tmp/envtest-assets")
+	env := newEnvironment("/tmp/envtest-assets", testK8sVersion(27))
 	env.startAPIServerFn = func(_ *controllerruntimeenvtest.APIServer) error { return nil }
 	env.addAdminUserFn = func(_ *controllerruntimeenvtest.ControlPlane) (*rest.Config, error) {
 		return &rest.Config{Host: "https://127.0.0.1:6443"}, nil
@@ -34,7 +43,7 @@ func TestEnvironmentStartUsesConfiguredStorageEndpointAndPrefix(t *testing.T) {
 	endpoint, err := url.Parse("http://127.0.0.1:2379")
 	require.NoError(t, err)
 
-	env := newEnvironment("/tmp/envtest-assets")
+	env := newEnvironment("/tmp/envtest-assets", testK8sVersion(27))
 	env.startAPIServerFn = func(_ *controllerruntimeenvtest.APIServer) error { return nil }
 	env.addAdminUserFn = func(_ *controllerruntimeenvtest.ControlPlane) (*rest.Config, error) {
 		return &rest.Config{Host: "https://127.0.0.1:6443"}, nil
@@ -52,11 +61,68 @@ func TestEnvironmentStartUsesConfiguredStorageEndpointAndPrefix(t *testing.T) {
 	assert.Equal(t, []string{"/registry/test"}, apiServer.Configure().Get("etcd-prefix").Get(nil))
 }
 
+func TestEnvironmentStartDefaultsWatchListFeatureGateForSupportedVersion(t *testing.T) {
+	endpoint, err := url.Parse("http://127.0.0.1:2379")
+	require.NoError(t, err)
+
+	env := newEnvironment("/tmp/envtest-assets", testK8sVersion(27))
+	env.startAPIServerFn = func(_ *controllerruntimeenvtest.APIServer) error { return nil }
+	env.addAdminUserFn = func(_ *controllerruntimeenvtest.ControlPlane) (*rest.Config, error) {
+		return &rest.Config{Host: "https://127.0.0.1:6443"}, nil
+	}
+
+	_, err = env.Start(WithDatastoreEndpoint(endpoint))
+	require.NoError(t, err)
+
+	apiServer := env.ControlPlane.GetAPIServer()
+	assert.Equal(t, []string{"WatchList=true"}, apiServer.Configure().Get("feature-gates").Get(nil))
+}
+
+func TestEnvironmentStartSkipsWatchListFeatureGateForUnsupportedVersion(t *testing.T) {
+	endpoint, err := url.Parse("http://127.0.0.1:2379")
+	require.NoError(t, err)
+
+	env := newEnvironment("/tmp/envtest-assets", testK8sVersion(26))
+	env.startAPIServerFn = func(_ *controllerruntimeenvtest.APIServer) error { return nil }
+	env.addAdminUserFn = func(_ *controllerruntimeenvtest.ControlPlane) (*rest.Config, error) {
+		return &rest.Config{Host: "https://127.0.0.1:6443"}, nil
+	}
+
+	_, err = env.Start(WithDatastoreEndpoint(endpoint))
+	require.NoError(t, err)
+
+	apiServer := env.ControlPlane.GetAPIServer()
+	assert.Nil(t, apiServer.Configure().Get("feature-gates").Get(nil))
+}
+
+func TestEnvironmentStartUsesExplicitFeatureGates(t *testing.T) {
+	endpoint, err := url.Parse("http://127.0.0.1:2379")
+	require.NoError(t, err)
+
+	env := newEnvironment("/tmp/envtest-assets", testK8sVersion(27))
+	env.startAPIServerFn = func(_ *controllerruntimeenvtest.APIServer) error { return nil }
+	env.addAdminUserFn = func(_ *controllerruntimeenvtest.ControlPlane) (*rest.Config, error) {
+		return &rest.Config{Host: "https://127.0.0.1:6443"}, nil
+	}
+
+	_, err = env.Start(
+		WithDatastoreEndpoint(endpoint),
+		WithAPIServerFeatureGates(map[string]bool{
+			"OtherFeature": true,
+			"WatchList":    false,
+		}),
+	)
+	require.NoError(t, err)
+
+	apiServer := env.ControlPlane.GetAPIServer()
+	assert.Equal(t, []string{"OtherFeature=true,WatchList=false"}, apiServer.Configure().Get("feature-gates").Get(nil))
+}
+
 func TestEnvironmentStopStopsOnlyAPIServer(t *testing.T) {
 	endpoint, err := url.Parse("http://127.0.0.1:2379")
 	require.NoError(t, err)
 
-	env := newEnvironment("/tmp/envtest-assets")
+	env := newEnvironment("/tmp/envtest-assets", testK8sVersion(27))
 
 	stopped := 0
 	env.startAPIServerFn = func(_ *controllerruntimeenvtest.APIServer) error { return nil }

--- a/pkg/envtest/options.go
+++ b/pkg/envtest/options.go
@@ -10,7 +10,7 @@ import (
 type Option func(*env.Env)
 
 // StartOption allows to configure runtime API server startup.
-type StartOption func(*APIServerStorageConfig)
+type StartOption func(*APIServerStartConfig)
 
 // Arch can override default go runtime detected system arch. This can be useful
 // when running on `arm64` and envtest binaries are not available for the platform.
@@ -22,14 +22,36 @@ func Arch(arch string) Option {
 
 // WithDatastoreEndpoint configures the datastore endpoint used by the API server.
 func WithDatastoreEndpoint(endpoint *url.URL) StartOption {
-	return func(cfg *APIServerStorageConfig) {
-		cfg.Endpoint = endpoint
+	return func(cfg *APIServerStartConfig) {
+		cfg.Storage.Endpoint = endpoint
 	}
 }
 
 // WithDatastorePrefix configures kube-apiserver --etcd-prefix value.
 func WithDatastorePrefix(prefix string) StartOption {
-	return func(cfg *APIServerStorageConfig) {
-		cfg.Prefix = prefix
+	return func(cfg *APIServerStartConfig) {
+		cfg.Storage.Prefix = prefix
+	}
+}
+
+// WithAPIServerFeatureGate configures a kube-apiserver --feature-gates entry.
+func WithAPIServerFeatureGate(name string, enabled bool) StartOption {
+	return func(cfg *APIServerStartConfig) {
+		if cfg.FeatureGates == nil {
+			cfg.FeatureGates = map[string]bool{}
+		}
+		cfg.FeatureGates[name] = enabled
+	}
+}
+
+// WithAPIServerFeatureGates configures kube-apiserver --feature-gates entries.
+func WithAPIServerFeatureGates(featureGates map[string]bool) StartOption {
+	return func(cfg *APIServerStartConfig) {
+		if cfg.FeatureGates == nil {
+			cfg.FeatureGates = map[string]bool{}
+		}
+		for name, enabled := range featureGates {
+			cfg.FeatureGates[name] = enabled
+		}
 	}
 }

--- a/pkg/envtest/setup.go
+++ b/pkg/envtest/setup.go
@@ -46,7 +46,7 @@ func Prepare(ctx context.Context, b bundle.Bundle, opts ...Option) (*Environment
 	}
 
 	log.Printf("Using envtest binaries from directory: %s\n", binaryAssetsDirectory)
-	return newEnvironment(binaryAssetsDirectory), nil
+	return newEnvironment(binaryAssetsDirectory, detectedK8sVersion), nil
 }
 
 func setupEnvtest(ctx context.Context, e *env.Env) (_ string, err error) {


### PR DESCRIPTION
Enable WatchClient feature flag for API server where this feature is supported.