### PR TITLE
feat: rewrite describe output

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,8 +1,10 @@
 package proxy
 
 import (
+	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 
 	"k8s.io/client-go/rest"
 )
@@ -21,6 +23,34 @@ func ReverseProxyForAPIServerHandler(cfg *rest.Config) (*httputil.ReverseProxy, 
 	}
 
 	proxy := httputil.NewSingleHostReverseProxy(apiServerURL)
+	director := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		director(req)
+		preferJSONOverProtobuf(req)
+	}
 	proxy.Transport = transport
 	return proxy, nil
+}
+
+func preferJSONOverProtobuf(req *http.Request) {
+	accept := req.Header.Get("Accept")
+	if accept == "" || !strings.Contains(accept, "application/vnd.kubernetes.protobuf") {
+		return
+	}
+
+	acceptedTypes := strings.Split(accept, ",")
+	jsonAcceptedTypes := make([]string, 0, len(acceptedTypes))
+	for _, acceptedType := range acceptedTypes {
+		acceptedType = strings.TrimSpace(acceptedType)
+		if acceptedType == "" || strings.Contains(acceptedType, "application/vnd.kubernetes.protobuf") {
+			continue
+		}
+		jsonAcceptedTypes = append(jsonAcceptedTypes, acceptedType)
+	}
+
+	if len(jsonAcceptedTypes) == 0 {
+		req.Header.Set("Accept", "application/json")
+		return
+	}
+	req.Header.Set("Accept", strings.Join(jsonAcceptedTypes, ", "))
 }

--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -60,3 +60,43 @@ func TestProxyWithPrefixStripsPrefixBeforeForwarding(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "/api/v1/pods", gotPath)
 }
+
+func TestPreferJSONOverProtobuf(t *testing.T) {
+	tests := []struct {
+		name   string
+		accept string
+		want   string
+	}{
+		{
+			name:   "removes protobuf when json fallback exists",
+			accept: "application/vnd.kubernetes.protobuf, application/json",
+			want:   "application/json",
+		},
+		{
+			name:   "preserves non protobuf media types",
+			accept: "application/vnd.kubernetes.protobuf, application/json;as=Table;v=v1;g=meta.k8s.io, application/json",
+			want:   "application/json;as=Table;v=v1;g=meta.k8s.io, application/json",
+		},
+		{
+			name:   "falls back to json when only protobuf is accepted",
+			accept: "application/vnd.kubernetes.protobuf",
+			want:   "application/json",
+		},
+		{
+			name:   "leaves json request unchanged",
+			accept: "application/json",
+			want:   "application/json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/pods", nil)
+			req.Header.Set("Accept", tt.accept)
+
+			preferJSONOverProtobuf(req)
+
+			assert.Equal(t, tt.want, req.Header.Get("Accept"))
+		})
+	}
+}


### PR DESCRIPTION
Requesting JSON format for `describe` commands will trigger rewriter and fix the object events.