### PR TITLE
perf(importer): implement streaming worker pool to fix OOM - concurrency

### DIFF
--- a/pkg/importer/crds.go
+++ b/pkg/importer/crds.go
@@ -216,6 +216,9 @@ func waitForCRDsEstablished(ctx context.Context, cfg *importerConfig, crdNames [
 				if apierrors.IsNotFound(err) || isRetryableImportErr(err) {
 					continue
 				}
+				if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+					break
+				}
 				return fmt.Errorf("failed checking CRD %q established condition: %w", name, err)
 			}
 			if established {

--- a/pkg/importer/crds.go
+++ b/pkg/importer/crds.go
@@ -2,12 +2,19 @@ package importer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -15,6 +22,12 @@ import (
 	"github.com/mhrabovcin/troubleshoot-live/pkg/bundle"
 	"github.com/mhrabovcin/troubleshoot-live/pkg/cli"
 )
+
+var crdGVR = schema.GroupVersionResource{
+	Group:    "apiextensions.k8s.io",
+	Version:  "v1",
+	Resource: "customresourcedefinitions",
+}
 
 func loadCRDs(b bundle.Bundle) (*unstructured.UnstructuredList, error) {
 	crdsPath := filepath.Join(b.Layout().ClusterResources(), "custom-resource-definitions.json")
@@ -63,13 +76,16 @@ func importCRDs(
 
 	cfg.out.Infof("Processing %d records from CRD file", len(list.Items))
 
-	return list.EachListItem(func(in runtime.Object) error {
+	tasks := make([]importTask, 0, len(list.Items))
+	var prepareErrors []error
+	err = list.EachListItem(func(in runtime.Object) error {
 		u, err := asUnstructured(in)
 		if err != nil {
-			return err
+			prepareErrors = append(prepareErrors, err)
+			return nil
 		}
 
-		gvr, includeStatus, err := detectGVR(cfg.discoveryClient, u)
+		gvr, includeStatus, err := cfg.gvrResolver.Detect(u)
 		cfg.out.V(5).Infof("CRD import: detected %s %q", u.GetName(), gvr)
 
 		// Assume that k8s api server doesn't know about the old apiextensions v1beta1
@@ -78,11 +94,19 @@ func importCRDs(
 			cfg.out.V(1).Infof("Attempting to convert CRD %s from v1beta1 to v1", u.GetName())
 			v1beta1Extension := &apiextensionsv1beta1.CustomResourceDefinition{}
 			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, v1beta1Extension); err != nil {
-				return fmt.Errorf("failed to convert CRD unstructured to v1beta1 extension %q: %w", u.GetName(), err)
+				prepareErrors = append(
+					prepareErrors,
+					fmt.Errorf("failed to convert CRD unstructured to v1beta1 extension %q: %w", u.GetName(), err),
+				)
+				return nil
 			}
 			v1Extension, err := convertCRD(v1beta1Extension)
 			if err != nil {
-				return fmt.Errorf("failed to convert CRD from v1beta1 to v1: %w", err)
+				prepareErrors = append(
+					prepareErrors,
+					fmt.Errorf("failed to convert CRD from v1beta1 to v1 for %q: %w", u.GetName(), err),
+				)
+				return nil
 			}
 
 			if crdHasNonStructuralSchema(v1Extension) {
@@ -90,29 +114,67 @@ func importCRDs(
 				v1Extension.Spec.PreserveUnknownFields = false
 			}
 
-			gvr = schema.GroupVersionResource{
-				Group:    "apiextensions.k8s.io",
-				Version:  "v1",
-				Resource: "customresourcedefinitions",
-			}
+			gvr = crdGVR
 			includeStatus = true
 			uMap, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(v1Extension)
-			in = &unstructured.Unstructured{Object: uMap}
+			u = &unstructured.Unstructured{Object: uMap}
 		}
 
-		uImport, err := asUnstructured(in)
+		tasks = append(tasks, importTask{
+			sourcePath:    filepath.Join(cfg.bundle.Layout().ClusterResources(), "custom-resource-definitions.json"),
+			gvr:           gvr,
+			object:        u.DeepCopy(),
+			includeStatus: includeStatus,
+		})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	importedCRDs := []string{}
+	var crdsMu sync.Mutex
+
+	// We use a custom worker pool to only track successfully imported CRDs
+	wp := newWorkerPool(ctx, defaultImportWorkers, func(innerCtx context.Context, task importTask) error {
+		err := importObjectWithRetry(innerCtx, cfg.dynamicClient, task.gvr, task.object, task.includeStatus, cfg.objectPreparer)
 		if err != nil {
+			cfg.out.Warnf(
+				"Failed to import %q (%s) from %q with error: %s",
+				objectReference(task.object), task.gvr, task.sourcePath, err,
+			)
 			return err
 		}
 
-		err = importObject(ctx, cfg.dynamicClient, gvr, uImport, includeStatus, cfg.objectPreparer)
-		if err != nil {
-			cfg.out.Warnf(
-				"Failed to import CRD %q (%s) with error: %s", u.GetName(), gvr, err,
-			)
-		}
+		// Only track successfully imported CRDs to avoid 60s timeout in waitForCRDsEstablished
+		crdsMu.Lock()
+		importedCRDs = append(importedCRDs, task.object.GetName())
+		crdsMu.Unlock()
 		return nil
 	})
+
+	var allErrors []error
+	allErrors = append(allErrors, prepareErrors...)
+
+	for _, task := range tasks {
+		addErr := wp.Add(ctx, task)
+		if addErr != nil {
+			allErrors = append(allErrors, addErr)
+			break // Context cancelled
+		}
+	}
+
+	waitPoolErr := wp.Wait()
+	allErrors = append(allErrors, errorOrNil(waitPoolErr)...)
+
+	if len(importedCRDs) > 0 {
+		waitStart := time.Now()
+		waitErr := waitForCRDsEstablished(ctx, cfg, importedCRDs)
+		cfg.out.V(1).Infof("Waited %s for %d CRDs to be established", time.Since(waitStart).Round(time.Millisecond), len(importedCRDs))
+		allErrors = append(allErrors, errorOrNil(waitErr)...)
+	}
+
+	return errors.Join(allErrors...)
 }
 
 // IsStatusConditionPresentAndEqual returns true when conditionType is present and equal to status.
@@ -123,4 +185,88 @@ func crdHasNonStructuralSchema(crd *apiextensionsv1.CustomResourceDefinition) bo
 		}
 	}
 	return false
+}
+
+func waitForCRDsEstablished(ctx context.Context, cfg *importerConfig, crdNames []string) error {
+	if len(crdNames) == 0 {
+		return nil
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, cfg.crdWaitTimeout)
+	defer cancel()
+
+	pending := map[string]struct{}{}
+	for _, name := range crdNames {
+		if name != "" {
+			pending[name] = struct{}{}
+		}
+	}
+
+	if len(pending) == 0 {
+		return nil
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		for name := range pending {
+			established, err := isCRDEstablished(waitCtx, cfg, name)
+			if err != nil {
+				if apierrors.IsNotFound(err) || isRetryableImportErr(err) {
+					continue
+				}
+				return fmt.Errorf("failed checking CRD %q established condition: %w", name, err)
+			}
+			if established {
+				delete(pending, name)
+			}
+		}
+
+		if len(pending) == 0 {
+			return nil
+		}
+
+		select {
+		case <-waitCtx.Done():
+			notReadyCRDs := make([]string, 0, len(pending))
+			for name := range pending {
+				notReadyCRDs = append(notReadyCRDs, name)
+			}
+			sort.Strings(notReadyCRDs)
+			return fmt.Errorf(
+				"timed out waiting for CRDs to be established after %s: %s",
+				cfg.crdWaitTimeout,
+				strings.Join(notReadyCRDs, ", "),
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+func isCRDEstablished(ctx context.Context, cfg *importerConfig, crdName string) (bool, error) {
+	crd, err := cfg.dynamicClient.Resource(crdGVR).Get(ctx, crdName, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	conditions, found, err := unstructured.NestedSlice(crd.Object, "status", "conditions")
+	if err != nil || !found {
+		return false, err
+	}
+
+	for _, conditionRaw := range conditions {
+		condition, ok := conditionRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		conditionType, _ := condition["type"].(string)
+		conditionStatus, _ := condition["status"].(string)
+		if conditionType == "Established" && conditionStatus == "True" {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/importer/gvr.go
+++ b/pkg/importer/gvr.go
@@ -53,10 +53,6 @@ func (r *gvrResolver) Detect(u *unstructured.Unstructured) (schema.GroupVersionR
 	return gvr, includeStatus, nil
 }
 
-func detectGVR(cl discovery.DiscoveryInterface, u *unstructured.Unstructured) (schema.GroupVersionResource, bool, error) {
-	return detectGVRUncached(cl, u)
-}
-
 func detectGVRUncached(cl discovery.DiscoveryInterface, u *unstructured.Unstructured) (schema.GroupVersionResource, bool, error) {
 	resourcesList, err := cl.ServerResourcesForGroupVersion(u.GetAPIVersion())
 	if err != nil {

--- a/pkg/importer/import.go
+++ b/pkg/importer/import.go
@@ -7,6 +7,8 @@ import (
 	"io/fs"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/mesosphere/dkp-cli-runtime/core/output"
 	"github.com/spf13/afero"
@@ -15,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -25,6 +28,100 @@ import (
 	"github.com/mhrabovcin/troubleshoot-live/pkg/cli"
 	"github.com/mhrabovcin/troubleshoot-live/pkg/utils"
 )
+
+const (
+	defaultImportWorkers  = 8
+	defaultCRDWaitTimeout = 60 * time.Second
+)
+
+var importRetryBackoff = wait.Backoff{
+	Steps:    5,
+	Duration: 100 * time.Millisecond,
+	Factor:   2.0,
+	Jitter:   0.2,
+}
+
+type importTask struct {
+	sourcePath    string
+	gvr           schema.GroupVersionResource
+	object        *unstructured.Unstructured
+	includeStatus bool
+}
+
+type workerPool struct {
+	jobs chan importTask
+	wg   sync.WaitGroup
+	mu   sync.Mutex
+	errs []error
+	once sync.Once
+}
+
+func newWorkerPool(ctx context.Context, workers int, handler func(context.Context, importTask) error) *workerPool {
+	if workers < 1 {
+		workers = 1
+	}
+	wp := &workerPool{
+		jobs: make(chan importTask, workers*2), // Buffer to avoid blocking disk I/O
+	}
+
+	for i := 0; i < workers; i++ {
+		wp.wg.Add(1)
+		go func() {
+			defer wp.wg.Done()
+			for task := range wp.jobs {
+				if err := handler(ctx, task); err != nil {
+					wp.mu.Lock()
+					wp.errs = append(wp.errs, err)
+					wp.mu.Unlock()
+				}
+			}
+		}()
+	}
+	return wp
+}
+
+// Add returns an error if the context is cancelled, preventing silent task loss.
+func (wp *workerPool) Add(ctx context.Context, task importTask) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case wp.jobs <- task:
+		return nil
+	}
+}
+
+// Close ensures the channel is closed safely and idempotently.
+func (wp *workerPool) Close() {
+	wp.once.Do(func() {
+		close(wp.jobs)
+	})
+}
+
+// Wait closes the channel and blocks until all workers finish.
+func (wp *workerPool) Wait() error {
+	wp.Close() // Ensure the channel is closed before waiting
+	wp.wg.Wait()
+
+	wp.mu.Lock()
+	defer wp.mu.Unlock()
+	if len(wp.errs) == 0 {
+		return nil
+	}
+	return errors.Join(wp.errs...)
+}
+
+func newImportWorkerPool(ctx context.Context, cfg *importerConfig) *workerPool {
+	return newWorkerPool(ctx, defaultImportWorkers, func(innerCtx context.Context, task importTask) error {
+		err := importObjectWithRetry(innerCtx, cfg.dynamicClient, task.gvr, task.object, task.includeStatus, cfg.objectPreparer)
+		if err != nil {
+			cfg.out.Warnf(
+				"Failed to import %q (%s) from %q with error: %s",
+				objectReference(task.object), task.gvr, task.sourcePath, err,
+			)
+		}
+		return err
+	})
+}
 
 // ImportBundle creates resources in provided API server.
 func ImportBundle(ctx context.Context, b bundle.Bundle, restCfg *rest.Config, out output.Output) error {
@@ -44,8 +141,11 @@ func ImportBundle(ctx context.Context, b bundle.Bundle, restCfg *rest.Config, ou
 		bundle:          b,
 		out:             out,
 		objectPreparer:  defaultObjectPreparer(),
+		gvrResolver:     newGVRResolver(discoveryClient),
+		crdWaitTimeout:  defaultCRDWaitTimeout,
 	}
 
+	var importErrors []error
 	importers := []importerFn{
 		importCRDs,
 		importNamespaces,
@@ -54,7 +154,6 @@ func ImportBundle(ctx context.Context, b bundle.Bundle, restCfg *rest.Config, ou
 		importSecrets,
 	}
 
-	var importErrors []error
 	for _, importerFn := range importers {
 		if err := importerFn(ctx, cfg); err != nil {
 			importErrors = append(importErrors, err)
@@ -76,6 +175,8 @@ type importerConfig struct {
 	bundle          bundle.Bundle
 	out             output.Output
 	objectPreparer  ObjectPreparer
+	gvrResolver     *gvrResolver
+	crdWaitTimeout  time.Duration
 }
 
 type importerFn func(context.Context, *importerConfig) error
@@ -83,12 +184,12 @@ type importerFn func(context.Context, *importerConfig) error
 func importNamespaces(
 	ctx context.Context,
 	cfg *importerConfig,
-) error {
+) (err error) {
 	namespacesPath := filepath.Join(cfg.bundle.Layout().ClusterResources(), "namespaces.json")
-	list, err := bundle.LoadResourcesFromFile(cfg.bundle, namespacesPath)
-	if err != nil {
+	list, loadErr := bundle.LoadResourcesFromFile(cfg.bundle, namespacesPath)
+	if loadErr != nil {
 		cli.WarnOnErrorsFilePresence(cfg.bundle, cfg.out, namespacesPath)
-		return err
+		return loadErr
 	}
 
 	populateGVK(list, schema.GroupVersionKind{
@@ -96,34 +197,56 @@ func importNamespaces(
 		Kind:    "Namespace",
 	})
 
-	namespaces := []string{}
-	gvr, includeStatus, err := detectGVR(cfg.discoveryClient, &list.Items[0])
-	if err != nil {
-		return err
+	if len(list.Items) == 0 {
+		return nil
 	}
-	return list.EachListItem(func(o runtime.Object) error {
-		u, err := asUnstructured(o)
-		if err != nil {
-			return err
+
+	gvr, includeStatus, detectErr := cfg.gvrResolver.Detect(&list.Items[0])
+	if detectErr != nil {
+		return detectErr
+	}
+
+	cfg.out.V(1).Infof("Importing namespaces concurrently...")
+	wp := newImportWorkerPool(ctx, cfg)
+
+	defer func() {
+		if wErr := wp.Wait(); wErr != nil {
+			err = errors.Join(err, wErr)
 		}
-		namespaces = append(namespaces, u.GetName())
-		return importObject(ctx, cfg.dynamicClient, gvr, u, includeStatus, cfg.objectPreparer)
-	})
+	}()
+
+	var prepareErrors []error
+	for i := range list.Items {
+		u, errUns := asUnstructured(&list.Items[i])
+		if errUns != nil {
+			prepareErrors = append(prepareErrors, errUns)
+			continue
+		}
+
+		addErr := wp.Add(ctx, importTask{
+			sourcePath:    namespacesPath,
+			gvr:           gvr,
+			object:        u.DeepCopy(),
+			includeStatus: includeStatus,
+		})
+		if addErr != nil {
+			prepareErrors = append(prepareErrors, addErr)
+			break // Context cancelled
+		}
+	}
+
+	return errors.Join(prepareErrors...)
 }
 
 func importClusterResources(
 	ctx context.Context,
 	cfg *importerConfig,
-) error {
+) (err error) {
 	skipResources := []string{
-		// crds are imported during a separate step
 		"custom-resource-definitions.json",
 		"pod-disruption-budgets-info.json",
-		// api-resources from the discovery client
 		"resources.json",
-		// api-groups from the discovery client
 		"groups.json",
-		// namespaces are imported as first resource in a separate step
 		"namespaces.json",
 	}
 
@@ -132,34 +255,43 @@ func importClusterResources(
 		"pod-disruption-budgets",
 	}
 
-	return afero.Walk(cfg.bundle, cfg.bundle.Layout().ClusterResources(), func(path string, info fs.FileInfo, err error) error {
-		if err != nil {
-			cfg.out.Warnf("Failed to read file %q from bundle: %s", path, err)
+	cfg.out.V(1).Infof("Importing cluster resources concurrently...")
+	wp := newImportWorkerPool(ctx, cfg)
+
+	defer func() {
+		if wErr := wp.Wait(); wErr != nil {
+			err = errors.Join(err, wErr)
+		}
+	}()
+
+	var importErrors []error
+	walkErr := afero.Walk(cfg.bundle, cfg.bundle.Layout().ClusterResources(), func(path string, info fs.FileInfo, walkErr error) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if walkErr != nil {
+			cfg.out.Warnf("Failed to read file %q from bundle: %s", path, walkErr)
 			return nil
 		}
 
-		// Do not process any resources from the directory
 		if info.IsDir() && slices.Contains(skipDirs, filepath.Base(info.Name())) {
 			return fs.SkipDir
 		}
 
-		if info.IsDir() {
+		if info.IsDir() || slices.Contains(skipResources, filepath.Base(info.Name())) {
 			return nil
 		}
 
-		if slices.Contains(skipResources, filepath.Base(info.Name())) {
-			return nil
-		}
-
-		// skip failed resources
 		if strings.HasSuffix(strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)), "-errors") {
 			return nil
 		}
 
-		list, err := bundle.LoadResourcesFromFile(cfg.bundle, path)
-		if err != nil {
+		list, loadErr := bundle.LoadResourcesFromFile(cfg.bundle, path)
+		if loadErr != nil {
 			cli.WarnOnErrorsFilePresence(cfg.bundle, cfg.out, path)
-			cfg.out.Errorf(utils.MaxErrorString(err, 200), "Failed to load resources from file %q", path)
+			cfg.out.Errorf(utils.MaxErrorString(loadErr, 200), "Failed to load resources from file %q", path)
+			importErrors = append(importErrors, loadErr)
 			return nil
 		}
 
@@ -167,45 +299,45 @@ func importClusterResources(
 			return nil
 		}
 
-		// Kind was not stored in older troubleshoot versions for non-CRDs, try to
-		// figure out the kind by the filename.
 		if list.Items[0].GetKind() == "" {
-			relPath, err := filepath.Rel(cfg.bundle.Layout().ClusterResources(), path)
-			if err != nil {
-				return fmt.Errorf("failed to detect kind for path %q: %w", path, err)
+			relPath, relErr := filepath.Rel(cfg.bundle.Layout().ClusterResources(), path)
+			if relErr != nil {
+				return fmt.Errorf("failed to detect kind for path %q: %w", path, relErr)
 			}
-			if gvk, err := gvkFromFile(relPath); err == nil {
-				populateGVK(list, gvk)
+			if gvkLocal, errFromFile := gvkFromFile(relPath); errFromFile == nil {
+				populateGVK(list, gvkLocal)
 			}
 		}
 
-		cfg.out.V(1).Infof("Importing objects from: %s ...", path)
+		cfg.out.V(1).Infof("Loading objects from: %s ...", path)
 
-		gvr, includeStatus, err := detectGVR(cfg.discoveryClient, &list.Items[0])
-		if err != nil {
-			cfg.out.Errorf(err, "failed to detect GVR from file %q. CRD for the resource may not be imported:", path)
+		gvr, includeStatus, detectErr := cfg.gvrResolver.Detect(&list.Items[0])
+		if detectErr != nil {
+			cfg.out.Errorf(detectErr, "failed to detect GVR from file %q. CRD for the resource may not be imported:", path)
+			importErrors = append(importErrors, detectErr)
 			return nil
 		}
 
-		_ = list.EachListItem(func(o runtime.Object) error {
-			u, err := asUnstructured(o)
-			if err != nil {
-				cfg.out.Warnf("Failed to convert object from %q with error: %s", path, err)
-				return nil
+		for i := range list.Items {
+			addErr := wp.Add(ctx, importTask{
+				sourcePath:    path,
+				gvr:           gvr,
+				object:        list.Items[i].DeepCopy(),
+				includeStatus: includeStatus,
+			})
+			if addErr != nil {
+				return addErr // Context cancelled, abort Walk
 			}
-
-			err = importObject(ctx, cfg.dynamicClient, gvr, u, includeStatus, cfg.objectPreparer)
-			if err != nil {
-				cfg.out.Warnf(
-					"Failed to import %q (%s) with error: %s",
-					fmt.Sprintf("%s/%s", u.GetNamespace(), u.GetName()), gvr, err,
-				)
-			}
-			return nil
-		})
+		}
 
 		return nil
 	})
+
+	if walkErr != nil {
+		importErrors = append(importErrors, walkErr)
+	}
+
+	return errors.Join(importErrors...)
 }
 
 type cmOrSecretLoadFn func(afero.Fs, string) (*unstructured.Unstructured, error)
@@ -216,10 +348,24 @@ func importCMOrSecrets(
 	path string,
 	loadFn cmOrSecretLoadFn,
 	gvr schema.GroupVersionResource,
-) error {
-	return afero.Walk(cfg.bundle, path, func(path string, info fs.FileInfo, err error) error {
-		if err != nil {
-			cfg.out.Errorf(err, "Failed to read file %q from bundle", path)
+) (err error) {
+	wp := newImportWorkerPool(ctx, cfg)
+
+	defer func() {
+		if wErr := wp.Wait(); wErr != nil {
+			err = errors.Join(err, wErr)
+		}
+	}()
+
+	var importErrors []error
+	walkErr := afero.Walk(cfg.bundle, path, func(path string, info fs.FileInfo, walkErr error) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if walkErr != nil {
+			cfg.out.Errorf(walkErr, "Failed to read file %q from bundle", path)
+			importErrors = append(importErrors, walkErr)
 			return nil
 		}
 
@@ -229,18 +375,31 @@ func importCMOrSecrets(
 
 		cfg.out.V(1).Infof("Importing %s from: %s ... ", gvr.Resource, path)
 
-		obj, err := loadFn(cfg.bundle, path)
-		if err != nil {
-			cfg.out.Errorf(utils.MaxErrorString(err, 200), "Failed to import secret from %q", path)
+		obj, loadErr := loadFn(cfg.bundle, path)
+		if loadErr != nil {
+			cfg.out.Errorf(utils.MaxErrorString(loadErr, 200), "Failed to import secret from %q", path)
+			importErrors = append(importErrors, loadErr)
 			return nil
 		}
 
-		if err := importObject(ctx, cfg.dynamicClient, gvr, obj, true, cfg.objectPreparer); err != nil {
-			return err
+		addErr := wp.Add(ctx, importTask{
+			sourcePath:    path,
+			gvr:           gvr,
+			object:        obj,
+			includeStatus: true,
+		})
+		if addErr != nil {
+			return addErr // Context cancelled, abort Walk
 		}
 
 		return nil
 	})
+
+	if walkErr != nil {
+		importErrors = append(importErrors, walkErr)
+	}
+
+	return errors.Join(importErrors...)
 }
 
 func importCMs(
@@ -275,20 +434,38 @@ func importObject(
 	includeStatus bool,
 	preparer ObjectPreparer,
 ) error {
+	_, err := importObjectWithResult(ctx, cl, gvr, o, includeStatus, preparer)
+	return err
+}
+
+// importObjectWithResult returns true if the object was created, or an error otherwise.
+func importObjectWithResult(
+	ctx context.Context,
+	cl dynamic.Interface,
+	gvr schema.GroupVersionResource,
+	o *unstructured.Unstructured,
+	includeStatus bool,
+	preparer ObjectPreparer,
+) (bool, error) {
 	if err := preparer.Prepare(o); err != nil {
-		return err
+		return false, err
 	}
 
 	_, err := cl.Resource(gvr).Namespace(o.GetNamespace()).Get(ctx, o.GetName(), metav1.GetOptions{})
-	if err != nil && apierrors.IsNotFound(err) {
-		nsClient := cl.Resource(gvr).Namespace(o.GetNamespace())
-		err := createResource(ctx, o, includeStatus, nsClient)
-		if err != nil {
-			return fmt.Errorf("failed to import resource: %w", err)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("failed to get resource: %w", err)
 		}
+		nsClient := cl.Resource(gvr).Namespace(o.GetNamespace())
+
+		created, err := createResource(ctx, o, includeStatus, nsClient)
+		if err != nil {
+			return false, fmt.Errorf("failed to import resource: %w", err)
+		}
+		return created, nil
 	}
 
-	return nil
+	return false, nil
 }
 
 func asUnstructured(o runtime.Object) (*unstructured.Unstructured, error) {
@@ -299,18 +476,21 @@ func asUnstructured(o runtime.Object) (*unstructured.Unstructured, error) {
 	return u, nil
 }
 
-func createResource(ctx context.Context, u *unstructured.Unstructured, includeStatus bool, nsClient dynamic.ResourceInterface) error {
+func createResource(ctx context.Context, u *unstructured.Unstructured, includeStatus bool, nsClient dynamic.ResourceInterface) (bool, error) {
 	_, err := nsClient.Create(ctx, u, metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to create resource: %w", err)
+		if apierrors.IsAlreadyExists(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to create resource: %w", err)
 	}
 
 	// Only import status for objects with status field
 	if _, ok := u.Object["status"]; !ok || !includeStatus {
-		return nil
+		return true, nil
 	}
 
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		updated, err := nsClient.Get(ctx, u.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to load created object: %w", err)
@@ -326,4 +506,56 @@ func createResource(ctx context.Context, u *unstructured.Unstructured, includeSt
 		}
 		return nil
 	})
+
+	return true, err
+}
+
+func objectReference(u *unstructured.Unstructured) string {
+	if u == nil {
+		return "<nil>"
+	}
+	if u.GetNamespace() == "" {
+		return u.GetName()
+	}
+	return fmt.Sprintf("%s/%s", u.GetNamespace(), u.GetName())
+}
+
+func importObjectWithRetry(
+	ctx context.Context,
+	cl dynamic.Interface,
+	gvr schema.GroupVersionResource,
+	o *unstructured.Unstructured,
+	includeStatus bool,
+	preparer ObjectPreparer,
+) error {
+	return retry.OnError(importRetryBackoff, isRetryableImportErr, func() error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return importObject(ctx, cl, gvr, o.DeepCopy(), includeStatus, preparer)
+	})
+}
+
+func isRetryableImportErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	return apierrors.IsTooManyRequests(err) ||
+		apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsInternalError(err) ||
+		apierrors.IsNotFound(err)
+}
+
+func errorOrNil(err error) []error {
+	if err == nil {
+		return nil
+	}
+	return []error{err}
 }

--- a/pkg/importer/parallel_test.go
+++ b/pkg/importer/parallel_test.go
@@ -1,0 +1,226 @@
+package importer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+)
+
+type countingDiscovery struct {
+	discovery.DiscoveryInterface
+	calls int32
+}
+
+func (c *countingDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	atomic.AddInt32(&c.calls, 1)
+	return c.DiscoveryInterface.ServerResourcesForGroupVersion(groupVersion)
+}
+
+func TestWorkerPoolRunsTasksInParallel(t *testing.T) {
+	t.Parallel()
+
+	const taskCount = 32
+	tasks := make([]importTask, 0, taskCount)
+	for i := 0; i < taskCount; i++ {
+		tasks = append(tasks, importTask{
+			sourcePath: fmt.Sprintf("task-%02d", i),
+		})
+	}
+
+	var inFlight int32
+	var maxInFlight int32
+	var processed int32
+	wp := newWorkerPool(context.Background(), 8, func(_ context.Context, _ importTask) error {
+		current := atomic.AddInt32(&inFlight, 1)
+		defer atomic.AddInt32(&inFlight, -1)
+		atomic.AddInt32(&processed, 1)
+
+		for {
+			prev := atomic.LoadInt32(&maxInFlight)
+			if current <= prev {
+				break
+			}
+			if atomic.CompareAndSwapInt32(&maxInFlight, prev, current) {
+				break
+			}
+		}
+
+		time.Sleep(5 * time.Millisecond)
+		return nil
+	})
+
+	for _, task := range tasks {
+		if err := wp.Add(context.Background(), task); err != nil {
+			t.Fatalf("unexpected add error: %v", err)
+		}
+	}
+
+	if err := wp.Wait(); err != nil {
+		t.Fatalf("wait failed: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&processed); got != taskCount {
+		t.Fatalf("expected %d processed tasks, got %d", taskCount, got)
+	}
+	if maxInFlight < 2 {
+		t.Fatalf("expected concurrent execution, max in-flight=%d", maxInFlight)
+	}
+}
+
+func TestWorkerPoolAggregatesErrors(t *testing.T) {
+	t.Parallel()
+
+	tasks := []importTask{
+		{sourcePath: "task-1"},
+		{sourcePath: "task-2"},
+		{sourcePath: "task-3"},
+	}
+
+	wp := newWorkerPool(context.Background(), 4, func(_ context.Context, task importTask) error {
+		if task.sourcePath == "task-2" {
+			return nil
+		}
+		return fmt.Errorf("failed %s", task.sourcePath)
+	})
+
+	for _, task := range tasks {
+		if err := wp.Add(context.Background(), task); err != nil {
+			t.Fatalf("unexpected add error: %v", err)
+		}
+	}
+
+	err := wp.Wait()
+	if err == nil {
+		t.Fatal("expected aggregated error but got nil")
+	}
+	if !strings.Contains(err.Error(), "failed task-1") {
+		t.Fatalf("expected task-1 error in %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "failed task-3") {
+		t.Fatalf("expected task-3 error in %q", err.Error())
+	}
+}
+
+func TestGVRResolverCachesDiscoveryLookups(t *testing.T) {
+	t.Parallel()
+
+	clientset := kubernetesfake.NewSimpleClientset()
+	fakeDiscovery := clientset.Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDiscovery.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "configmaps", Kind: "ConfigMap"},
+				{Name: "configmaps/status", Kind: "ConfigMap"},
+			},
+		},
+	}
+
+	discovery := &countingDiscovery{DiscoveryInterface: fakeDiscovery}
+	resolver := newGVRResolver(discovery)
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+		},
+	}
+
+	_, _, err := resolver.Detect(obj)
+	if err != nil {
+		t.Fatalf("first detect failed: %v", err)
+	}
+
+	_, _, err = resolver.Detect(obj)
+	if err != nil {
+		t.Fatalf("second detect failed: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&discovery.calls); got != 1 {
+		t.Fatalf("expected 1 discovery call due to cache hit, got %d", got)
+	}
+}
+
+func TestWaitForCRDsEstablished(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			crdGVR: "CustomResourceDefinitionList",
+		},
+		&unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "apiextensions.k8s.io/v1",
+				"kind":       "CustomResourceDefinition",
+				"metadata": map[string]any{
+					"name": "widgets.example.com",
+				},
+				"status": map[string]any{
+					"conditions": []any{
+						map[string]any{
+							"type":   "Established",
+							"status": "True",
+						},
+					},
+				},
+			},
+		},
+	)
+
+	cfg := &importerConfig{
+		dynamicClient:  client,
+		crdWaitTimeout: 50 * time.Millisecond,
+	}
+
+	if err := waitForCRDsEstablished(context.Background(), cfg, []string{"widgets.example.com"}); err != nil {
+		t.Fatalf("waitForCRDsEstablished returned error: %v", err)
+	}
+}
+
+func TestWaitForCRDsEstablishedTimeout(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			crdGVR: "CustomResourceDefinitionList",
+		},
+		&unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "apiextensions.k8s.io/v1",
+				"kind":       "CustomResourceDefinition",
+				"metadata": map[string]any{
+					"name": "notready.example.com",
+				},
+			},
+		},
+	)
+
+	cfg := &importerConfig{
+		dynamicClient:  client,
+		crdWaitTimeout: 25 * time.Millisecond,
+	}
+
+	err := waitForCRDsEstablished(context.Background(), cfg, []string{"notready.example.com"})
+	if err == nil {
+		t.Fatal("expected timeout error but got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out waiting for CRDs") {
+		t.Fatalf("expected timeout error, got: %v", err)
+	}
+}


### PR DESCRIPTION
This PR is the second part split out from #183 . This introduces concurrency mechanisms to reduce the startup time of the `troubleshoot-live serve` command. While the core phases remain sequential to respect resource dependencies (CRDs, Namespaces, etc.), the processing of individual objects within those phases has been parallelized.

### Summary of Changes

* **Parallel resource loading**: Implemented a streaming worker pool pattern to handle object discovery and creation concurrently, avoiding the previous strictly synchronous bottlenecks while preventing out-of-memory (OOM) issues on large bundles.
* **Scope and Reliability**: Kept the import concurrency fixed at 8 workers to align with the current main behavior (configurability intentionally deferred to keep the scope tight). It also preserves best-effort execution with aggregated errors, ensuring partial data from support bundles remains available for triage instead of failing fast on the first error.
* **Test coverage**: Added comprehensive unit tests in parallel_test.go to validate parallel execution, best-effort error aggregation, and timeout handling.

Any feedback is appreciated, and I can make any changes if needed.

Thanks!